### PR TITLE
Update GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build SST Spatter
+name: Build and Run
 
 on:
   push:
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-sst-spatter:
+  build-and-run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SST Spatter
@@ -30,12 +30,9 @@ jobs:
           packages: libtool-bin libltdl-dev
           version: 1.0
 
-      - name: Set environment variables
-        run: |
-          echo "SPATTER_BUILD=$GITHUB_WORKSPACE/spatter/build_serial" >> $GITHUB_ENV
-          echo "SST_CORE_HOME=$HOME/local/sstcore-$SST_VERSION" >> $GITHUB_ENV
-          echo "SST_CORE_ROOT=$GITHUB_WORKSPACE/sstcore-$SST_VERSION" >> $GITHUB_ENV
-          echo "SST_SPATTER_HOME=$HOME/local/packages/sstspatter" >> $GITHUB_ENV
+      - name: Update PATH environment variable
+        run : |
+          echo "$HOME/local/sstcore-${SST_VERSION}/bin" >> $GITHUB_PATH
 
       - name: Restore SST Core cache
         id: cache-sst-core-restore
@@ -43,6 +40,13 @@ jobs:
         with:
           path: ~/local/sstcore-${{ env.SST_VERSION }}
           key: cache-sst-core-${{ env.SST_VERSION }}
+
+      - name: Restore SST Elements cache
+        id: cache-sst-elements-restore
+        uses: actions/cache/restore@v4
+        with:
+          path:  ~/local/sstelements-${{ env.SST_VERSION }}
+          key: cache-sst-elements-${{ env.SST_VERSION }}
 
       - name: Download SST Core
         if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
@@ -55,9 +59,35 @@ jobs:
         if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
         working-directory: sstcore-${{ env.SST_VERSION }}
         run: |
-          ./configure --prefix=$SST_CORE_HOME --disable-mpi
-          make -j$(nproc) all
-          make -j$(nproc) install
+          ./configure --prefix=${HOME}/local/sstcore-${SST_VERSION} --disable-mpi
+          make -j$(nproc) all; make install
+
+      - name: Download SST Elements
+        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/sstsimulator/sst-elements/archive/refs/tags/v${SST_VERSION}_Final.tar.gz -O sstelements-${SST_VERSION}.tar.gz
+          mkdir -p sstelements-${SST_VERSION}
+          tar xfz sstelements-${SST_VERSION}.tar.gz -C sstelements-${SST_VERSION} --strip-components=1
+
+      - name: Ignore unused elements
+        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
+        working-directory: sstelements-${{ env.SST_VERSION }}
+        run: |
+          for element in src/sst/elements/*/; do
+            if [[ ! "${element}" == *"memHierarchy/" ]]; then
+              cd ${GITHUB_WORKSPACE}/sstelements-${SST_VERSION}/${element}
+              touch .ignore
+            fi
+          done
+
+      - name: Install SST Elements
+        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
+        working-directory: sstelements-${{ env.SST_VERSION }}
+        run: |
+          ./autogen.sh
+          ./configure --prefix=${HOME}/local/sstelements-${SST_VERSION} \
+            --with-sst-core=${HOME}/local/sstcore-${SST_VERSION}
+          make -j$(nproc) all; make install
 
       - name: Save SST Core cache
         if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
@@ -65,6 +95,13 @@ jobs:
         with:
           path: ~/local/sstcore-${{ env.SST_VERSION }}
           key: ${{ steps.cache-sst-core-restore.outputs.cache-primary-key }}
+
+      - name: Save SST Elements cache
+        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path:  ~/local/sstelements-${{ env.SST_VERSION }}
+          key: ${{ steps.cache-sst-elements-restore.outputs.cache-primary-key }}
 
       - name: Checkout Spatter
         uses: actions/checkout@v4
@@ -83,6 +120,12 @@ jobs:
         working-directory: sst-spatter
         run: |
           ./autogen.sh
-          ./configure --prefix=$SST_SPATTER_HOME --with-sst-core=$SST_CORE_HOME --with-spatter=$SPATTER_BUILD
-          make -j$(nproc) all
-          make -j$(nproc) install
+          ./configure --prefix=${HOME}/local/packages/sstspatter \
+            --with-sst-core=${HOME}/local/sstcore-${SST_VERSION} \
+            --with-spatter=${GITHUB_WORKSPACE}/spatter/build_serial
+          make -j$(nproc) all; make install
+
+      - name: Run SST Spatter
+        working-directory: sst-spatter
+        run: |
+          sst tests/sst_spatter_spr.py -- -p UNIFORM:8:1


### PR DESCRIPTION
This PR updates the current GitHub Actions workflow to build and run the element.

- Saves SST Core install path to PATH environment variable
- Added SST Elements to workflow since SST Spatter SDL files rely on memHierarchy
- Ignores all unused elements to reduce build time of SST Elements
- Saves SST Core cache after installing SST Elements to ensure memHierarchy remains registered
- Caches SST Elements install path to reduce build time for subsequent workflow runs
- Uses a simple Spatter pattern to check if the element runs without error
