### PR TITLE
Switch to using Installed Spatter Library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           ./autogen.sh
           ./configure --prefix=${HOME}/local/packages/sstspatter \
             --with-sst-core=${HOME}/local/sstcore-${SST_VERSION} \
-            --with-spatter=${HOME}/packages/spatter
+            --with-spatter=${HOME}/local/packages/spatter
           make -j$(nproc) all; make install
 
       - name: Run SST Spatter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Build Spatter
         working-directory: spatter
         run: |
-          cmake -B build_serial -S .
-          make -j$(nproc) -C build_serial
+          cmake -DCMAKE_INSTALL_PREFIX=${HOME}/local/packages/spatter -B build_serial -S .
+          make -j$(nproc) all -C build_serial; make install -C build_serial
 
       - name: Build SST Spatter
         working-directory: sst-spatter
@@ -122,7 +122,7 @@ jobs:
           ./autogen.sh
           ./configure --prefix=${HOME}/local/packages/sstspatter \
             --with-sst-core=${HOME}/local/sstcore-${SST_VERSION} \
-            --with-spatter=${GITHUB_WORKSPACE}/spatter/build_serial
+            --with-spatter=${HOME}/packages/spatter
           make -j$(nproc) all; make install
 
       - name: Run SST Spatter

--- a/config/sst_check_spatter.m4
+++ b/config/sst_check_spatter.m4
@@ -13,13 +13,13 @@ AC_DEFUN([SST_CHECK_SPATTER],
 
   AS_IF([test "$sst_check_spatter_happy" = "yes"], [
     AS_IF([test ! -z "$with_spatter" -a "$with_spatter" != "yes"],
-      [SPATTER_CPPFLAGS="-I$with_spatter/../src/ -I$with_spatter/../src/Spatter -I$with_spatter/_deps/nlohmann_json-src/include"
+      [SPATTER_CPPFLAGS="-I$with_spatter/include -I$with_spatter/include/Spatter"
        CXXFLAGS="$AM_CXXFLAGS $CXXFLAGS"
        CPPFLAGS="$SPATTER_CPPFLAGS $AM_CPPFLAGS $CPPFLAGS"
-       SPATTER_LDFLAGS="-L$with_spatter/src/Spatter -L$with_spatter/src/"
+       SPATTER_LDFLAGS="-L$with_spatter/lib -L$with_spatter"
        LDFLAGS="$SPATTER_LDFLAGS $AM_LDFLAGS $LDFLAGS"
        SPATTER_LIB="-lSpatter"
-       SPATTER_LIBDIR="$with_spatter/src/Spatter/"],
+       SPATTER_LIBDIR="$with_spatter/lib"],
       [SPATTER_CXXFLAGS=
        SPATTER_CPPFLAGS=
        SPATTER_LDFLAGS=
@@ -27,8 +27,7 @@ AC_DEFUN([SST_CHECK_SPATTER],
        SPATTER_LIBDIR=])])
   
   AC_LANG_PUSH([C++])
-  AC_CHECK_HEADERS([nlohmann/json.hpp \
-                    Configuration.hh \
+  AC_CHECK_HEADERS([Configuration.hh \
                     Input.hh \
                     JSONParser.hh \
                     PatternParser.hh \


### PR DESCRIPTION
Updated CMake to search for the Spatter library and headers in the installed path instead of the build path.

Future work:
- [x] Update GitHub workflow to use Spatter install path
- [ ] Update the SST Spatter Apptainer definitions

~~Note: this PR relies on the changes in https://github.com/hpcgarage/spatter/pull/238, which have not yet been merged.~~