### PR TITLE
Update SST-Spatter documentation

### DIFF
--- a/CONTRIBUTORS.TXT
+++ b/CONTRIBUTORS.TXT
@@ -1,7 +1,0 @@
-Copyright 2009-2024, Sandia National Laboratories
-
-Portions are copyright of other developers including:
-International Business Machines (IBM) 2016-2024
-Cray Inc 2014-2024
-Intel 2023
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ make install
 ```
 
 ## SST-Spatter Build and Installation
-1. CLone the SST-Spatter element.
+1. Clone the SST-Spatter element.
 ```
 cd $HOME/scratch/src
 git clone https://github.com/hpcgarage/sst-spatter.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,68 @@
+# Build and Installation Instructions for SST-Spatter
+
+## External Dependent Components
+
+### SST 14.1.0
+See [Detailed Installation Instructions](https://sst-simulator.org/SSTPages/SSTBuildAndInstall_14dot1dot0_SeriesDetailedBuildInstructions/) for installing SST 14.1.0.
+
+### Spatter 2.0.0+ (spatter-devel branch)
+1. Clone the Spatter benchmark.
+```
+cd $HOME/scratch/src
+git clone https://github.com/hpcgarage/spatter.git
+cd spatter
+git checkout spatter-devel
+```
+
+2. Set the home directory environment variable of the Spatter installation.
+```
+export SPATTER_HOME=$HOME/local/packages/spatter
+```
+
+3. Configure the build and installation of Spatter.
+```
+cmake -DCMAKE_INSTALL_PREFIX=$SPATTER_HOME -B build_serial -S .
+```
+
+4. Build and install Spatter.
+```
+cd build_serial
+make all
+make install
+```
+
+## SST-Spatter Build and Installation
+1. CLone the SST-Spatter element.
+```
+cd $HOME/scratch/src
+git clone https://github.com/hpcgarage/sst-spatter.git
+cd sst-spatter
+```
+2. Set the home directory environment variable of the SST-Spatter installation.
+```
+export SST_SPATTER_HOME=$HOME/local/packages/sstspatter
+```
+
+3. Create a configure file.
+```
+./autogen.sh
+```
+
+4. Configure the build and installation of SST-Spatter.
+```
+./configure --prefix=$SST_SPATTER_HOME --with-sst-core=$SST_CORE_HOME \
+  --with-spatter=$SPATTER_HOME
+```
+
+5. Build and install SST-Spatter.
+```
+make all
+make install
+```
+
+6. Test your SST-Spatter install.
+```
+sst --version
+sst-info
+sst-test-elements -w "*spatter*"
+```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,6 +11,10 @@ Copyright (c) 2009-2024, NTESS
 
 All rights reserved.
 
+Copyright (c) 2023, HPCGarage Research Group at Georgia Tech
+
+All rights reserved.
+
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@ Copyright (c) 2009-2024, NTESS
 
 All rights reserved.
 
-Copyright (c) 2023, HPCGarage Research Group at Georgia Tech
+Copyright (c) 2025, HPCGarage Research Group at Georgia Tech
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ See [INSTALL.md](INSTALL.md) for build and installation instructions.
 
 SST-Spatter supports the same command-line arguments as Spatter; see [Running Spatter](https://github.com/hpcgarage/spatter/blob/main/README.md#running-spatter) for details. In addition to these arguments, the statistics level and statistics output file can be specified with the `--statlevel` and `--statfile` flags.
 
-Note: the SST-Spatter command-line arguments must be preceded by `--`, so they can be appended to the model options and passed to the SST configuration file.
+Note: the SST-Spatter command-line arguments must be preceded by `--` so they can be appended to the model options and passed to the SST configuration file.
 
 ```
-sst $SST_SPATTER_HOME/src/tests/sst_spatter.py -- -p UNIFORM:8:1 -l$((2**16))
+sst tests/sst_spatter_spr.py -- -p UNIFORM:8:1 -l$((2**16))
 
 0:cpu:RequestGenCPU[RequestGenCPU:43]: Configured CPU to allow 16 maximum Load requests to be memory to be outstanding.
 0:cpu:RequestGenCPU[RequestGenCPU:45]: Configured CPU to allow 16 maximum Store requests to be memory to be outstanding.
@@ -58,7 +58,7 @@ sst $SST_SPATTER_HOME/src/tests/sst_spatter.py -- -p UNIFORM:8:1 -l$((2**16))
 Simulation is complete, simulated time: 737.562 us
 ```
 
-This will generate output to both the command-line and a statistics file, named `stats.out` by default.
+This will generate output to both the command-line and a statistics file, named `stats.csv` by default.
 
 ## SST-Spatter Output
 The output to the command-line contains SST configuration information, which is specified in the SST configuration file.
@@ -66,7 +66,7 @@ The output to the command-line contains SST configuration information, which is 
 The statistics file contains the SST-Spatter statistics output for the simulated runs, saved in a CSV file format.
 
 ```
-cat stats.out
+head -n 19 stats.csv
 
 ComponentName, StatisticName, StatisticSubId, StatisticType, SimTime, Rank, Sum.u64, SumSQ.u64, Count.u64, Min.u64, Max.u64
 cpu, read_reqs, , Accumulator, 737561682, 0, 466944, 466944, 466944, 1, 1
@@ -92,7 +92,7 @@ cpu, cycles, , Accumulator, 737561682, 0, 2578887, 2578887, 2578887, 1, 1
 To compare this output with Spatter runs, you can use the [spatter_stats.py](tools/spatter_stats.py) helper script to convert the data in the statistics file into Spatter-like statistics.
 
 ```
-python3 $SST_SPATTER_HOME/src/tools/spatter_stats.py stats.out
+python3 tools/spatter_stats.py stats.csv
 
 config         bytes          time(s)        bw(MB/s)       cycles         
 0              4194304        0.000737562    5686.72        2578887

--- a/README.md
+++ b/README.md
@@ -1,22 +1,88 @@
-![SST](http://sst-simulator.org/img/sst-logo-small.png)
+# SST-Spatter
+SST-Spatter is an external element that simulates gather and scatter operations by replaying Spatter traces, also known as Spatter patterns. It is based on the Miranda element and incorporates the Spatter library to support the same configuration options that Spatter uses to specify one or more patterns.
 
-# Structural Simulation Toolkit (SST)
+For more details about Spatter and its configuration options, see [Spatter](https://github.com/hpcgarage/spatter/blob/main/README.md).
 
-#### Copyright (c) 2009-2024, National Technology and Engineering Solutions of Sandia, LLC (NTESS)
-Portions are copyright of other developers:
-See the file CONTRIBUTORS.TXT in the top level directory
-of this repository for more information.
+## Building SST-Spatter
 
----
+See [INSTALL.md](INSTALL.md) for build and installation instructions.
 
-The Structural Simulation Toolkit (SST) was developed to explore innovations in highly concurrent systems where the ISA, microarchitecture, and memory interact with the programming model and communications system. The package provides two novel capabilities. The first is a fully modular design that enables extensive exploration of an individual system parameter without the need for intrusive changes to the simulator. The second is a parallel simulation environment based on MPI. This provides a high level of performance and the ability to look at large systems. The framework has been successfully used to model concepts ranging from processing in memory to conventional processors connected by conventional network interfaces and running MPI.
+## Running SST-Spatter
 
----
+SST-Spatter supports the same command-line arguments as Spatter; see [Running Spatter](https://github.com/hpcgarage/spatter/blob/main/README.md#running-spatter) for details. In addition to these arguments, the statistics level and statistics output file can be specified with the `--statlevel` and `--statfile` flags.
 
-Visit [sst-simulator.org](http://sst-simulator.org) to learn more about SST.
+Note: the SST-Spatter command-line arguments must be preceded by `--`, so they can be appended to the model options and passed to the SST configuration file.
 
-See [SST Elements Documentation](http://sst-simulator.org/SSTPages/SSTDeveloperElementSummaryInfo/) for an overview of the simulation capabilities in this repository.
+```
+sst $SST_SPATTER_HOME/src/tests/sst_spatter.py -- -p UNIFORM:8:1 -l$((2**16))
 
-See [Contributing](https://github.com/sstsimulator/sst-elements/blob/devel/CONTRIBUTING.md) to learn how to contribute to SST.
+0:cpu:RequestGenCPU[RequestGenCPU:43]: Configured CPU to allow 16 maximum Load requests to be memory to be outstanding.
+0:cpu:RequestGenCPU[RequestGenCPU:45]: Configured CPU to allow 16 maximum Store requests to be memory to be outstanding.
+0:cpu:RequestGenCPU[RequestGenCPU:47]: Configured CPU to allow 16 maximum Custom requests to be memory to be outstanding.
+0:cpu:RequestGenCPU[RequestGenCPU:54]: CPU clock configured for 3.5GHz
+0:cpu:RequestGenCPU[RequestGenCPU:60]: Memory interface to be loaded is: memHierarchy.standardInterface
+0:cpu:RequestGenCPU[RequestGenCPU:75]: Loaded memory interface successfully.
+0:cpu:RequestGenCPU[RequestGenCPU:103]: Generator loaded successfully.
+0:cpu:RequestGenCPU[RequestGenCPU:160]: Miranda CPU Configuration:
+0:cpu:RequestGenCPU[RequestGenCPU:161]: - Max requests per cycle:         5
+0:cpu:RequestGenCPU[RequestGenCPU:162]: - Max reorder lookups             256
+0:cpu:RequestGenCPU[RequestGenCPU:163]: - Clock:                          3.5GHz
+0:cpu:RequestGenCPU[RequestGenCPU:164]: - Cache line size:                64 bytes
+0:cpu:RequestGenCPU[RequestGenCPU:165]: - Max Load requests pending:      16
+0:cpu:RequestGenCPU[RequestGenCPU:166]: - Max Store requests pending:     16
+0:cpu:RequestGenCPU[RequestGenCPU:167]: - Max Custom requests pending:     16
+0:cpu:RequestGenCPU[RequestGenCPU:168]: Configuration completed.
+0:TimingDRAM::TimingDRAM():52:mc=0: number of channels: 3
+0:TimingDRAM::TimingDRAM():53:mc=0: address mapper:     memHierarchy.roundRobinAddrMapper
+0:TimingDRAM:Channel:Channel():111:mc=0:chan=0: max pending trans: 32
+0:TimingDRAM:Channel:Channel():112:mc=0:chan=0: number of ranks:   2
+0:TimingDRAM:Rank:Rank():221:mc=0:chan=0:rank=0: number of banks: 16
+0:TimingDRAM:Bank:Bank():289:mc=0:chan=0:rank=0:bank=0: CL:           40
+0:TimingDRAM:Bank:Bank():290:mc=0:chan=0:rank=0:bank=0: CL_WR:        39
+0:TimingDRAM:Bank:Bank():291:mc=0:chan=0:rank=0:bank=0: RCD:          39
+0:TimingDRAM:Bank:Bank():292:mc=0:chan=0:rank=0:bank=0: TRP:          39
+0:TimingDRAM:Bank:Bank():293:mc=0:chan=0:rank=0:bank=0: dataCycles:   4
+0:TimingDRAM:Bank:Bank():294:mc=0:chan=0:rank=0:bank=0: transactionQ: memHierarchy.reorderTransactionQ
+0:TimingDRAM:Bank:Bank():295:mc=0:chan=0:rank=0:bank=0: pagePolicy:   memHierarchy.simplePagePolicy
+Simulation is complete, simulated time: 737.562 us
+```
 
-##### [LICENSE](https://github.com/sstsimulator/sst-elements/blob/devel/LICENSE.md)
+This will generate output to both the command-line and a statistics file, named `stats.out` by default.
+
+## SST-Spatter Output
+The output to the command-line contains SST configuration information, which is specified in the SST configuration file.
+
+The statistics file contains the SST-Spatter statistics output for the simulated runs, saved in a CSV file format.
+
+```
+cat stats.out
+
+ComponentName, StatisticName, StatisticSubId, StatisticType, SimTime, Rank, Sum.u64, SumSQ.u64, Count.u64, Min.u64, Max.u64
+cpu, read_reqs, , Accumulator, 737561682, 0, 466944, 466944, 466944, 1, 1
+cpu, write_reqs, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, custom_reqs, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, split_read_reqs, , Accumulator, 737561682, 0, 57344, 57344, 57344, 1, 1
+cpu, split_write_reqs, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, split_custom_reqs, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, completed_reqs, , Accumulator, 737561682, 0, 524288, 524288, 524288, 1, 1
+cpu, cycles_with_issue, , Accumulator, 737561682, 0, 524276, 524276, 524276, 1, 1
+cpu, cycles_no_issue, , Accumulator, 737561682, 0, 2054610, 2054610, 2054610, 1, 1
+cpu, total_bytes_read, , Accumulator, 737561682, 0, 4194304, 33554432, 524288, 8, 8
+cpu, total_bytes_write, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, total_bytes_custom, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, req_latency, , Accumulator, 737561682, 0, 11727476, 543265590, 581632, 6, 136
+cpu, time, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, cycles_hit_fence, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, cycles_max_issue, , Accumulator, 737561682, 0, 3, 3, 3, 1, 1
+cpu, cycles_max_reorder, , Accumulator, 737561682, 0, 0, 0, 0, 0, 0
+cpu, cycles, , Accumulator, 737561682, 0, 2578887, 2578887, 2578887, 1, 1
+```
+
+To compare this output with Spatter runs, you can use the [spatter_stats.py](tools/spatter_stats.py) helper script to convert the data in the statistics file into Spatter-like statistics.
+
+```
+python3 $SST_SPATTER_HOME/src/tools/spatter_stats.py stats.out
+
+config         bytes          time(s)        bw(MB/s)       cycles         
+0              4194304        0.000737562    5686.72        2578887
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ SST-Spatter is an external element that simulates gather and scatter operations 
 
 For more details about Spatter and its configuration options, see [Spatter](https://github.com/hpcgarage/spatter/blob/main/README.md).
 
+## Dependencies
+* SST 14.1.0
+* Spatter 2.0.0+ (spatter-devel brach)
+* Supported C++17 compiler (GCC, Clang)
+* GNU Make
+* GNU Autoconf 2.59+
+* GNU Automake 1.9.6+
+* GNU Libtool 1.5.22+
+* Python 3.6+
+* pandas
+
 ## Building SST-Spatter
 
 See [INSTALL.md](INSTALL.md) for build and installation instructions.


### PR DESCRIPTION
This pull request updates the documentation in the repository with SST Spatter-related information.

- Closes https://github.com/hpcgarage/sst-spatter/issues/6
- Closes https://github.com/hpcgarage/sst-spatter/issues/5
- Updates `README.md` with the dependencies and example of running SST-Spatter
- Updates `LICENSE.md` with new copyright holder information
- Adds `INSTALL.md` to include the build and installation instructions

Note: the Spatter installation instructions in `INSTALL.md` are based on the changes in https://github.com/hpcgarage/spatter/pull/238.