### PR TITLE
Update build.yml to run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,6 @@ jobs:
           path: ~/local/sstcore-${{ env.SST_VERSION }}
           key: cache-sst-core-${{ env.SST_VERSION }}
 
-      - name: Restore SST Elements cache
-        id: cache-sst-elements-restore
-        uses: actions/cache/restore@v4
-        with:
-          path:  ~/local/sstelements-${{ env.SST_VERSION }}
-          key: cache-sst-elements-${{ env.SST_VERSION }}
-
       - name: Download SST Core
         if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
         run: |
@@ -62,15 +55,20 @@ jobs:
           ./configure --prefix=${HOME}/local/sstcore-${SST_VERSION} --disable-mpi
           make -j$(nproc) all; make install
 
+      - name: Save SST Core cache
+        if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/local/sstcore-${{ env.SST_VERSION }}
+          key: ${{ steps.cache-sst-core-restore.outputs.cache-primary-key }}
+
       - name: Download SST Elements
-        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/sstsimulator/sst-elements/archive/refs/tags/v${SST_VERSION}_Final.tar.gz -O sstelements-${SST_VERSION}.tar.gz
           mkdir -p sstelements-${SST_VERSION}
           tar xfz sstelements-${SST_VERSION}.tar.gz -C sstelements-${SST_VERSION} --strip-components=1
 
       - name: Ignore unused elements
-        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
         working-directory: sstelements-${{ env.SST_VERSION }}
         run: |
           for element in src/sst/elements/*/; do
@@ -81,27 +79,12 @@ jobs:
           done
 
       - name: Install SST Elements
-        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
         working-directory: sstelements-${{ env.SST_VERSION }}
         run: |
           ./autogen.sh
           ./configure --prefix=${HOME}/local/sstelements-${SST_VERSION} \
             --with-sst-core=${HOME}/local/sstcore-${SST_VERSION}
           make -j$(nproc) all; make install
-
-      - name: Save SST Core cache
-        if: steps.cache-sst-core-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/local/sstcore-${{ env.SST_VERSION }}
-          key: ${{ steps.cache-sst-core-restore.outputs.cache-primary-key }}
-
-      - name: Save SST Elements cache
-        if: steps.cache-sst-elements-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path:  ~/local/sstelements-${{ env.SST_VERSION }}
-          key: ${{ steps.cache-sst-elements-restore.outputs.cache-primary-key }}
 
       - name: Checkout Spatter
         uses: actions/checkout@v4
@@ -126,6 +109,5 @@ jobs:
           make -j$(nproc) all; make install
 
       - name: Run SST Spatter Tests
-        working-directory: sst-spatter
         run: |
           sst-test-elements -w "*spatter*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Run
+name: Build and Test
 
 on:
   push:
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-run:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SST Spatter
@@ -74,7 +74,7 @@ jobs:
         working-directory: sstelements-${{ env.SST_VERSION }}
         run: |
           for element in src/sst/elements/*/; do
-            if [[ ! "${element}" == *"memHierarchy/" ]]; then
+            if [[ ! "${element}" == *"memHierarchy/" && ! "${element}" == *"cassini/" ]]; then
               cd ${GITHUB_WORKSPACE}/sstelements-${SST_VERSION}/${element}
               touch .ignore
             fi
@@ -125,7 +125,7 @@ jobs:
             --with-spatter=${HOME}/local/packages/spatter
           make -j$(nproc) all; make install
 
-      - name: Run SST Spatter
+      - name: Run SST Spatter Tests
         working-directory: sst-spatter
         run: |
-          sst tests/sst_spatter_spr.py -- -p UNIFORM:8:1
+          sst-test-elements -w "*spatter*"


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to run the SST-Spatter test suite.

- Removes cache step for SST Elements
- No longer ignores Cassini element
- Now runs the SST-Spatter tests