### PR TITLE
Cache align base addresses and fix address offsets

### DIFF
--- a/src/generators/spatterGenerator.cc
+++ b/src/generators/spatterGenerator.cc
@@ -367,7 +367,7 @@ void SpatterGenerator::updateIndices()
 void SpatterGenerator::gather()
 {
     sourceAddr = startSource + config->pattern[patternIdx] + config->delta * countIdx;
-    targetAddr = startTarget + config->pattern.size() * (countIdx % config->wrap);
+    targetAddr = startTarget + patternIdx + config->pattern.size() * (countIdx % config->wrap);
 
     MemoryOpRequest* readReq  = new MemoryOpRequest(sourceAddr, datawidth, READ);
     MemoryOpRequest* writeReq = new MemoryOpRequest(targetAddr, datawidth, WRITE);
@@ -389,7 +389,7 @@ void SpatterGenerator::gather()
    */
 void SpatterGenerator::scatter()
 {
-    sourceAddr = startTarget + config->pattern.size() * (countIdx % config->wrap);
+    sourceAddr = startTarget + patternIdx + config->pattern.size() * (countIdx % config->wrap);
     targetAddr = startSource + config->pattern[patternIdx] + config->delta * countIdx;
 
     MemoryOpRequest* readReq  = new MemoryOpRequest(sourceAddr, datawidth, READ);
@@ -436,7 +436,7 @@ void SpatterGenerator::gatherScatter()
 void SpatterGenerator::multiGather()
 {
     sourceAddr = startSource + config->pattern[config->pattern_gather[patternIdx]] + config->delta_gather * countIdx;
-    targetAddr = startTarget + config->pattern_gather.size() * (countIdx % config->wrap);
+    targetAddr = startTarget + patternIdx + config->pattern_gather.size() * (countIdx % config->wrap);
 
     MemoryOpRequest* readReq  = new MemoryOpRequest(sourceAddr, datawidth, READ);
     MemoryOpRequest* writeReq = new MemoryOpRequest(targetAddr, datawidth, WRITE);
@@ -458,7 +458,7 @@ void SpatterGenerator::multiGather()
    */
 void SpatterGenerator::multiScatter()
 {
-    sourceAddr = startTarget + config->pattern_scatter.size() * (countIdx % config->wrap);
+    sourceAddr = startTarget + patternIdx + config->pattern_scatter.size() * (countIdx % config->wrap);
     targetAddr = startSource + config->pattern[config->pattern_scatter[patternIdx]] + config->delta_scatter * countIdx;
 
     MemoryOpRequest* readReq  = new MemoryOpRequest(sourceAddr, datawidth, READ);

--- a/src/generators/spatterGenerator.h
+++ b/src/generators/spatterGenerator.h
@@ -52,6 +52,7 @@ public:
         { "verbose",            "Sets the verbosity of the output", "0" },
         { "args",               "Sets the arguments to describe Spatter pattern(s)", "" },
         { "datawidth",          "Sets the width of the memory operation", "8" },
+        { "cache_line_size",    "Size of the cache line the prefetcher is attached to", "64" },
         { "start_source",       "Sets the start address of the source array", "0" },
         { "start_target",       "Sets the start address of the target array", "0" },
         { "warmup_runs",        "Sets the the number of warm-up runs", "1" }
@@ -71,6 +72,8 @@ private:
     void tokenizeArgs(const std::string &args, const int32_t &argc, char ***argv);
     bool initConfigs(const std::string& args);
 
+    uint64_t alignAddress(const uint64_t cacheLineSize, const uint64_t address);
+
     size_t getPatternSize(const Spatter::ConfigurationBase *config);
     void updateIndices();
 
@@ -84,8 +87,9 @@ private:
     uint64_t sourceAddr;
     uint64_t targetAddr;
     uint32_t datawidth;
-    uint32_t startSource;
-    uint32_t startTarget;
+    uint64_t cacheLine;
+    uint64_t startSource;
+    uint64_t startTarget;
     uint32_t maxWarmupRuns;
     uint32_t remainingWarmupRuns;
 


### PR DESCRIPTION
This pull request addresses #25 by cache aligning the base addresses of the source and target addresses, and #26 by adding 'patternIdx' to correctly determine the address offsets in the kernels.

* Adds new `cache_line_size` parameter to the Spatter generator to align `start_source` and `start_target`
* Updates Gather, Scatter, MultiGather, and MultiScatter kernels to generate the correct address offsets
* Closes #25
* Closes #26